### PR TITLE
Fix incorrect platform enum values

### DIFF
--- a/blender_manifest_v1.schema.json
+++ b/blender_manifest_v1.schema.json
@@ -783,11 +783,11 @@
       "items": {
         "type": "string",
         "enum": [
-          "windows-amd64",
+          "windows-x64",
           "macos-arm64",
-          "linux-x86_64",
+          "linux-x64",
           "windows-arm64",
-          "macos-x86_64"
+          "macos-x64"
         ]
       },
       "minItems": 1,


### PR DESCRIPTION
See https://github.com/blender/blender/blob/8d97330482fe61ef1cfc9f762a60c95bdae1e6e5/scripts/addons_core/bl_pkg/cli/blender_ext.py#L2164

@BlenderDefender